### PR TITLE
Rename 'final' module to 'finalized' to avoid name collision with 'fi…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,15 +109,15 @@ at any point in time, you can use the `freeze` function instead:
     Traceback (most recent call last):
     AttributeError: 'Asset' instance is frozen, can't set attribute
 
-final
-^^^^^
+finalized
+^^^^^^^^^
 Runtime-checked version of the
 `typing.final <https://docs.python.org/3/library/typing.html#typing.final>`_ decorator.
 
 Can be used directly on methods but also on properties, classmethods, and staticmethods
 (even in Python 2.7).
 
-Features are also available through the metaclass `basicco.final.FinalMeta`.
+Features are also available through the metaclass `basicco.final.FinalizedMeta`.
 
 This decorator is still recognized by Mypy static type checking, and it also prevents
 subclassing and/or member overriding during runtime:

--- a/basicco/__init__.py
+++ b/basicco/__init__.py
@@ -5,7 +5,7 @@ from .reducible import ReducibleMeta
 from .explicit_hash import ExplicitHashMeta
 from .namespaced import NamespacedMeta
 from .abstract import abstract, is_abstract, is_abstract_member, AbstractMeta
-from .final import final, is_final, is_final_member, FinalMeta
+from .finalized import final, is_final, is_final_member, FinalizedMeta
 from .qualified import get_qualified_name, QualifiedMeta
 from .frozen import (
     FROZEN_SLOT,
@@ -41,7 +41,7 @@ __all__ = [
 
 class BaseMeta(
     FrozenMeta,
-    FinalMeta,
+    FinalizedMeta,
     AbstractMeta,
     QualifiedMeta,
     NamespacedMeta,
@@ -56,3 +56,10 @@ class Base(with_metaclass(BaseMeta, object)):
     """Base class."""
 
     __slots__ = (FROZEN_SLOT,)
+
+    def __ne__(self, other):
+        is_equal = self.__eq__(other)
+        if is_equal is NotImplemented:
+            return NotImplemented
+        else:
+            return not is_equal

--- a/basicco/finalized.py
+++ b/basicco/finalized.py
@@ -15,9 +15,9 @@ if TYPE_CHECKING:
     from typing import TypeVar, Optional, Type, Set
 
     T = TypeVar("T")
-    FT = TypeVar("FT", bound="FinalMeta")
+    FT = TypeVar("FT", bound="FinalizedMeta")
 
-__all__ = ["final", "is_final", "is_final_member", "FinalMeta"]
+__all__ = ["final", "is_final", "is_final_member", "FinalizedMeta"]
 
 _FINAL_CLASS_TAG = "__isfinalclass__"
 _FINAL_METHOD_TAG = "__isfinalmethod__"
@@ -69,11 +69,11 @@ def is_final_member(member):
     return _is_final
 
 
-class FinalMeta(type):
+class FinalizedMeta(type):
     """Enables runtime-checking for `final` decorator."""
 
     def __init__(cls, name, bases, dct, **kwargs):
-        super(FinalMeta, cls).__init__(name, bases, dct, **kwargs)
+        super(FinalizedMeta, cls).__init__(name, bases, dct, **kwargs)
         cls.__gather_final_members()
 
     def __gather_final_members(cls):
@@ -108,9 +108,9 @@ class FinalMeta(type):
             type.__setattr__(cls, _FINAL_METHODS, frozenset(final_member_names))
 
     def __setattr__(cls, name, value):
-        super(FinalMeta, cls).__setattr__(name, value)
+        super(FinalizedMeta, cls).__setattr__(name, value)
         cls.__gather_final_members()
 
     def __delattr__(cls, name):
-        super(FinalMeta, cls).__delattr__(name)
+        super(FinalizedMeta, cls).__delattr__(name)
         cls.__gather_final_members()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setuptools.setup(
     name="basicco",
-    version="0.5.0",
+    version="1.0.0",
     author="Bruno Nicko",
     author_email="brunonicko@gmail.com",
     description=(

--- a/tests/meta/test_final.py
+++ b/tests/meta/test_final.py
@@ -2,7 +2,7 @@ import pytest
 
 from six import with_metaclass
 
-from basicco.final import final, FinalMeta
+from basicco.finalized import final, FinalizedMeta
 
 
 @pytest.fixture()
@@ -12,7 +12,7 @@ def meta(pytestconfig):
         meta_module, meta_name = metacls.split("|")
         return getattr(__import__(meta_module, fromlist=[meta_name]), meta_name)
     else:
-        return FinalMeta
+        return FinalizedMeta
 
 
 def test_final_class(meta):


### PR DESCRIPTION
…nal' decorator